### PR TITLE
lst_to_sbom: remove reference to internal Siemens SBOM spec

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -1,0 +1,45 @@
+# This workflow will install Python dependencies and run some static checks
+
+# SPDX-FileCopyrightText: 2021-2025 Siemens
+# SPDX-FileContributor: Thomas Graf <thomas.graf@siemens.com>
+# SPDX-FileContributor: Gernot Hillier <gernot.hillier@siemens.com>
+# SPDX-License-Identifier: MIT
+
+name: Static Checks
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        cache: "poetry"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install poetry
+        poetry install --no-root
+
+    - name: Lint with flake8
+      run: |
+        poetry run flake8 .
+
+    - name: markdownlint
+      uses: nosborn/github-action-markdown-cli@v3.3.0
+      with:
+        files: .
+        config_file: .markdownlint.yaml

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2021-2025 Siemens
+# SPDX-FileContributor: Thomas Graf <thomas.graf@siemens.com>
+# SPDX-FileContributor: Gernot Hillier <gernot.hillier@siemens.com>
+# SPDX-License-Identifier: MIT
+
 name: Unit Tests
 
 on:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,17 @@
+# markdownlint YAML configuration
+
+# SPDX-FileCopyrightText: (c) 2018-2023 Siemens
+# SPDX-License-Identifier: MIT
+
+# For an example, see
+# https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.yaml
+
+# Default state for all rules
+default: true
+
+MD013:
+  # Number of characters
+  line_length: 100
+
+# MD041/first-line-heading/first-line-h1
+MD041: false

--- a/README.md
+++ b/README.md
@@ -94,8 +94,6 @@ poetry install
 poetry run python3 ./capywfa/capywfa.py ...
 ```
 
-If you experience Poetry issues, check the [Poetry Issues](#poetry-issues) section below.
-
 ## Installing as Python package (experimental)
 
 TODO: Not available on Github/PyPI yet.
@@ -107,18 +105,16 @@ part of the Poetry and Docker environments, you can verify that the upload
 succeeded and already existing releases have correct sources and meta data:
 
 ```shell
-$ python3 -m capycli bom Map --nocache -i package-list.json -t <sw360-token> -oa -o package-list-mapped.json
+$ python3 -m capycli bom Map --nocache -i packages-list.json -t <sw360-token> -oa -o packages-mapped.json
 [...]
 Mapping result:
   Full match by id, at, 3.1.23-1.debian => at daemon, 3.1.23-1.debian, b0667b7334c070cd2f05b071265ce7b3
-  Full match by id, software-properties, 0.96.20.2-2.debian => software-properties, 0.96.20.2-2.debian, c1d7bfc23140c099d5e39c7df35d828f
 [...]
-$ python3 -m capycli bom Map -i package-list.json -t <sw360-token> -oa -o package-list-mapped.json
-$ python3 -m capycli project Prerequisites -id <sw360-project-id> -i package-list-mapped.json -t <sw360-token> -oa
+$ python3 -m capycli project Prerequisites -id <project-id> -i packages-mapped.json -t <token> -oa
 [...]
   Components:
     software-properties, 0.96.20.2-2.debian: OPEN
-      Download URL: http://deb.debian.org/debian/pool/main/s/software-properties/software-properties_0.96.20.2-2.dsc
+      Download URL: http://deb.debian.org/debian/pool/main/s/software-properties_0.96.20.2-2.dsc
       SHA1 for source software-properties_0.96.20.2-2-debian-combined.tar.bz2 doesn't match!
       1 source file(s) available.
       component management id: {'package-url': 'pkg:deb/debian/software-properties@0.96.20.2-2?arch=source'}

--- a/capywfa/capywfa.py
+++ b/capywfa/capywfa.py
@@ -25,6 +25,8 @@ from capycli.project.create_project import CreateProject
 from cyclonedx.model import ExternalReferenceType
 from capywfa.cdx_support import get_cdx, set_cdx, legacy_to_cdx_prop
 
+args = None
+
 
 def write_bom(bom, outputname, check_length=True):
     prefix = datetime.datetime.now(tz=None).isoformat(timespec="seconds")
@@ -50,7 +52,6 @@ def write_bom(bom, outputname, check_length=True):
 
 
 def confirm(text):
-    global args
     if args.noninteractive:
         return None
     else:

--- a/capywfa/lst_to_sbom.py
+++ b/capywfa/lst_to_sbom.py
@@ -121,7 +121,7 @@ def lst_to_sbom(format, package_list, output_file):
 
     bom = {
         "bomFormat": "CycloneDX",
-        "specVersion": "1.4",
+        "specVersion": "1.6",
         "version": 1,
         "metadata": {
             "component": {
@@ -130,20 +130,11 @@ def lst_to_sbom(format, package_list, output_file):
             "tools": [
                 {
                     "vendor": "Siemens AG",
-                    "name": "standard-bom",
-                    "version": "2.0.0",
+                    "name": "capywfa",
+                    "version": importlib.metadata.version("capywfa"),
                     "externalReferences": [{
                         "type": "website",
-                        "url": "https://sbom.siemens.io/"}]
-                },
-                {
-                    "vendor": "Siemens AG",
-                    "name": "distroclearing",
-                    "version": importlib.metadata.version("distroclearing"),
-                    "externalReferences": [{
-                        "type": "website",
-                        "url": "https://code.siemens.com/"
-                            "linux/distro-clearing/distro-clearing"}]
+                        "url": "https://github.com/sw360/capywfa"}]
                 }]},
         "components": data}
 
@@ -160,11 +151,11 @@ def lst_to_sbom(format, package_list, output_file):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="convert Linux package list to Siemens SBOMv1 format",
+        description="convert Linux package list to CycloneDX format",
         formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("format", help="Can be 'deb' or 'apk'")
     parser.add_argument("package_list", help="Linux package_list")
-    parser.add_argument("output_file", help="BOM output file")
+    parser.add_argument("output_file", help="SBOM output file")
     args = parser.parse_args()
 
     lst_to_sbom(format=args.format, package_list=args.package_list,


### PR DESCRIPTION
Our internal "Siemens SBOM" is based on CycloneDX, so just refer to CycloneDX here.

Also, fix the component name.