### PR TITLE
docs: correct lst_to_sbom command syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ you have to convert your package list first:
 
 ```shell
 # convert Debian or Alpine package list to Standard BOM format:
-$ lst_to_sbom.py <package-list> package-list.json --pkg_dir /data/pkgs/
+$ lst_to_sbom.py <deb|apk> <package-list> package-list.json
 ```
 
 Now, check `capywfa.py --help` for the necessary parameters. The tool will guide


### PR DESCRIPTION
The current documentation of the usage of `lst_to_sbom.py` is obsolete. 